### PR TITLE
Integrate Claude-3-Sonnet into HybridAIClient

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ beautifulsoup4 = "*"
 duckduckgo-search = "*"
 pytest-asyncio = "*"
 coverage = "*"
+anthropic = "*"
 
 [dev-packages]
 isort = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a8b30e3a00c24948982be780399614570ba07dd83e6f644d35be46a59e56f5d6"
+            "sha256": "2f3c0a9d15bb9c488a067ab6c8e6efdcf9e02f9aa628cf09553f5e691014b431"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -126,6 +126,15 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.7.0"
+        },
+        "anthropic": {
+            "hashes": [
+                "sha256:5e94b571a3874295b6c8600d3797875abdca18946a9ade68b6aa0408caa31cad",
+                "sha256:e2495a07d14484f3219a5c0b902a63f9df8c2b3bd358f68b5ee86f1e89d1ba81"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.48.0"
         },
         "anyio": {
             "hashes": [
@@ -833,12 +842,12 @@
         },
         "openai": {
             "hashes": [
-                "sha256:20f85cde9e95e9fbb416e3cb5a6d3119c0b28308afd6e3cc47bf100623dac623",
-                "sha256:2861053538704d61340da56e2f176853d19f1dc5704bc306b7597155f850d57a"
+                "sha256:396652a6452dd42791b3ad8a3aab09b1feb7c1c4550a672586fb300760a8e204",
+                "sha256:9d9370a20d2b8c3ce319fd2194c2eef5eab59effbcc5b04ff480977edc530fba"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.64.0"
+            "version": "==1.65.1"
         },
         "packaging": {
             "hashes": [

--- a/ai_client.py
+++ b/ai_client.py
@@ -29,15 +29,16 @@ class HybridAIClient:
         self.completions = self
 
     def _convert_messages_for_anthropic(self, messages: List[Dict[str, str]]) -> List[Dict[str, str]]:
-        """Convert OpenAI message format to Anthropic format"""
+        """Convert OpenAI message format to Anthropic format.
+        Excludes system messages as they are handled separately."""
         role_mapping = {
-            "system": "system",
             "user": "user",
             "assistant": "assistant"
         }
         return [
             {"role": role_mapping[msg["role"]], "content": msg["content"]}
             for msg in messages
+            if msg["role"] != "system"
         ]
 
     def create(self, model: str, messages: List[Dict[str, str]]) -> Any:

--- a/ai_client.py
+++ b/ai_client.py
@@ -57,14 +57,12 @@ class HybridAIClient:
                     system=system_message
                 )
                 # Convert Anthropic response to OpenAI format
-                return type('AnthropicResponse', (), {
-                    'choices': [{
-                        'message': type('Message', (), {
-                            'content': response.content[0].text,
-                            'role': 'assistant'
-                        })
-                    }]
+                message = type('Message', (), {
+                    'content': response.content[0].text,
+                    'role': 'assistant'
                 })
+                choice = type('Choice', (), {'message': message})
+                return type('AnthropicResponse', (), {'choices': [choice]})
             except Exception as err:
                 logger.error(f"anthropic_client error: {err}")
                 return self.openai_client.chat.completions.create(

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ class ConfigTemplate:
     discord_api_key: str
     openai_api_key: str
     gemini_api_key: str
+    anthropic_api_key: str
     target_channnel_ids: list[int]
     role_prompt: str
     role_name: str
@@ -18,6 +19,7 @@ def load_config():
         discord_api_key=os.environ["DISCORD_API_KEY"],
         openai_api_key=os.environ["OPENAI_API_KEY"],
         gemini_api_key=os.environ["GEMINI_API_KEY"],
+        anthropic_api_key=os.environ.get("ANTHROPIC_API_KEY", ""),
         # Target channel IDs
         target_channnel_ids=list(map(int, os.environ["CHANNEL_IDS"].split(","))),
         # Roleplay settings

--- a/config.py
+++ b/config.py
@@ -19,9 +19,9 @@ def load_config():
         discord_api_key=os.environ["DISCORD_API_KEY"],
         openai_api_key=os.environ["OPENAI_API_KEY"],
         gemini_api_key=os.environ["GEMINI_API_KEY"],
-        anthropic_api_key=os.environ.get("ANTHROPIC_API_KEY", ""),
+        anthropic_api_key=os.environ["ANTHROPIC_API_KEY"],
         # Target channel IDs
-        target_channnel_ids=list(map(int, os.environ["CHANNEL_IDS"].split(","))),
+        target_channel_ids=list(map(int, os.environ["CHANNEL_IDS"].split(","))),
         # Roleplay settings
         role_prompt=os.environ["ROLE_PROMPT"],
         role_name=os.environ["ROLE_NAME"],

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ class ConfigTemplate:
     openai_api_key: str
     gemini_api_key: str
     anthropic_api_key: str
-    target_channnel_ids: list[int]
+    target_channel_ids: list[int]
     role_prompt: str
     role_name: str
 

--- a/discord_client.py
+++ b/discord_client.py
@@ -1,17 +1,12 @@
-import dataclasses
 import logging
 import os
-import re
 
 import discord
-import openai
-import requests
-from duckduckgo_search import DDGS
 
-import functions
-import summarizer
 from ai_client import load_ai_client
 from config import load_config
+from message_handler import process_message, send_messages
+from message_history import History
 
 intents = discord.Intents.default()
 intents.message_content = True
@@ -51,203 +46,30 @@ def validate_model(model: str) -> str:
 # デフォルトのテキストモデル（初期化時に検証）
 text_model = validate_model("gemini-2.0-flash")
 
-@dataclasses.dataclass
-class GPTMessage:
-    role: str
-    content: str
-
-
-class History:
-    def __init__(self, num_output=10):
-        self.messages = []
-        self.num_output = num_output
-
-    def add(self, message: GPTMessage):
-        self.messages.append(message)
-
-    def get_messages(self):
-        return [
-            dataclasses.asdict(message) for message in self.messages[-self.num_output:]
-        ]
-
-
 history = History()
 
 
-def search_and_summarize(user_question: str) -> str:
-    """
-    DuckDuckGo API を使って検索し、出てきた情報をまとめて Gemini で要約する。
-    """
+def ignore_message(message: discord.Message) -> bool:
+    """ボットのメッセージを無視"""
+    return message.author == client.user or message.author.bot
 
-    # 検索queryを作成
-    messages = [
-        {"role": "user", "content": user_question},
-        {
-            "role": "system",
-            "content": (
-                f"上記のユーザの質問「{user_question}」に対して、"
-                "検索するべき単語を抽出してください。回答は単語のみで構いません。"
-            ),
-        },
-    ]
-    try:
-        response = ai_client.chat.completions.create(
-            model=text_model,
-            messages=messages,
-        )
-        query = response.choices[0].message.content
-    except Exception as e:
-        logger.exception(e)
-        query = user_question
-
-    logger.info(f"Searching for: {query}")
-    # DuckDuckGo で検索
-    with DDGS() as ddgs:
-        results = list(ddgs.text(
-            keywords=query,
-            region='jp-jp',
-            max_results=10
-        ))
-
-    if not results:
-        return "検索結果が見つかりませんでした。"
-    
-    # 検索結果をまとめる
-    combined_text = f"{results}"
-
-    # モデルに送りすぎるとエラーになりやすいので適当にカット
-    combined_text = combined_text[:4096]
-
-    logger.info(f"Search snippets (trimmed): {combined_text[:100]}...")
-
-    if not combined_text.strip():
-        return "検索結果から有用な情報を取得できませんでした。"
-
-    # Gemini で要約
-    messages = [
-        {"role": "user", "content": combined_text},
-        {
-            "role": "system",
-            "content": (
-                f"上記の検索結果に基づいて、ユーザの質問「{query}」に答えるための"
-                "簡潔な日本語要約を作成してください。"
-            ),
-        },
-    ]
-    try:
-        response = ai_client.chat.completions.create(
-            model=text_model,
-            messages=messages,
-        )
-        summary = response.choices[0].message.content
-    except Exception as e:
-        logger.exception(e)
-        summary = "検索の要約時にエラーが発生しました。"
-    return summary
-
-
-def is_search_needed(user_message: str) -> bool:
-    """Determine if a search is needed based on the user's message."""
-    # Define keywords or patterns that indicate a search is needed
-    search_keywords = ["教えて", "とは", "何", "どうやって", "方法"]
-    if any(keyword in user_message for keyword in search_keywords):
-        return True
-
-    messages = [
-        {"role": "user", "content": user_message},
-        {
-            "role": "system",
-            "content": (
-                '上記のユーザーの発言に適切に答えるためにインターネット検索が必要であれば True、不要であれば False を返してください。必ず "True" または "False" のいずれかのみを返してください。'
-            ),
-        },
-    ]
-
-    try:
-        response = ai_client.chat.completions.create(
-            model=text_model,
-            messages=messages,
-        )
-        if "False" not in response.choices[0].message.content:
-            return True
-    except Exception as e:
-        logger.exception(e)
-    return False
-
-
-async def get_reply_message(message, optional_messages=[]):
-    """ユーザーのメッセージに対して、Gemini (via openai ライブラリ) による返信を取得する。
-    画像認識はできないので、画像要約だけ別途 openai_client を使う。
-    """
-    user_message = message.content
-    user_name = message.author.name
-
-    messages = history.get_messages()
-
-    # ロールプロンプトを system として追加
-    messages.append({"role": "system", "content": config.role_prompt})
-    # ユーザーからのメッセージ
-    messages.append({"role": "user", "content": user_name + ":\n" + user_message})
-    # LLMの知識不足を判定
-    if ai_client.is_knowledge_insufficient(text_model, messages):
-        logger.info("LLMの知識が不足しています。外部情報を検索します。")
-        summary = search_and_summarize(user_message)
-        optional_messages.append(
-            {
-                "role": "system",
-                "content": f"「{user_message}」の検索結果要約:\n{summary}"
-            }
-        )
-
-    # optional_messages があれば追記
-    if optional_messages:
-        messages.extend(optional_messages)
-    # アシスタント応答
-    messages.append({"role": "assistant", "content": config.role_name + ":\n"})
-
-    try:
-        # --- Gemini 側でチャット生成 ---
-        response = ai_client.chat.completions.create(
-            model=text_model,
-            messages=messages,
-        )
-        bot_reply_message = response.choices[0].message.content
-        bot_reply_message = bot_reply_message.replace(config.role_name + ":", "").strip()
-    except Exception as err:
-        logger.exception(err)
-        bot_reply_message = "Error: Gemini API failed"
-
-    # 履歴に追加
-    history.add(GPTMessage("user", user_name + ":\n" + user_message))
-    for optional_message in optional_messages:
-        history.add(GPTMessage(optional_message["role"], optional_message["content"]))
-    history.add(GPTMessage("assistant", config.role_name + ":\n" + bot_reply_message))
-
-    return bot_reply_message
-
+def check_if_channel_is_target(message: discord.Message) -> bool:
+    """対象チャンネルかどうかを確認"""
+    return message.channel.id in config.target_channnel_ids
 
 @client.event
 async def on_ready():
+    """ボット起動時の処理"""
     logger.info("We have logged in as {0.user}".format(client))
 
-
-def ignore_message(message):
-    return message.author == client.user or message.author.bot
-
-
-def check_if_channel_is_target(message):
-    return message.channel.id in config.target_channnel_ids
-
-
 @client.event
-async def on_message(message):
+async def on_message(message: discord.Message):
+    """メッセージ受信時の処理"""
     if ignore_message(message):
-        # ボット自身の発言は無視
         logger.info("ignore message")
         return
 
     if not check_if_channel_is_target(message):
-        # 対象チャンネル以外は無視
         logger.info("not target channel")
         return
 
@@ -255,72 +77,17 @@ async def on_message(message):
     logger.info(f"name:{message.author.name}")
     logger.info(f"message:{message.content[:50]}")
 
-    optional_messages = []
-
-    for attachment in message.attachments:
-        if not functions.is_image_attachment(attachment):
-            # 画像以外は無視
-            continue
-        try:
-            summarized_text = summarizer.summarize_image(attachment.url, ai_client)
-            logger.info(summarized_text[:50])
-            optional_messages.append(
-                {
-                    "role": "system",
-                    "content": "画像の要約:\n" + attachment.filename + "\n" + summarized_text
-                }
-            )
-        except RuntimeError:
-            pass
-
-    if functions.contains_url(message.content):
-        urls = functions.extract_urls(message.content)
-        try:
-            url = urls[0]
-            summarized_text = summarizer.summarize_webpage(url, ai_client)
-            logger.info(summarized_text[:50])
-            optional_messages.append(
-                {
-                    "role": "system",
-                    "content": "ページの要約:\n" + url + "\n" + summarized_text,
-                }
-            )
-        except RuntimeError:
-            pass
-
-    # --- ここから「～を教えて」を検出して検索する処理 ---
-    if is_search_needed(message.content):
-        # 検索して要約
-        summary = search_and_summarize(message.content)
-        # optional_messages に検索結果の要約を追加
-        optional_messages.append(
-            {
-                "role": "system",
-                "content": f"「{message.content}」の検索結果要約:\n{summary}"
-            }
+    async with message.channel.typing():
+        bot_reply_message = await process_message(
+            message,
+            history,
+            ai_client,
+            text_model,
+            config
         )
 
-    # 本文も添付もなく、かつ検索にもヒットしないなら返事しない
-    if not message.content and not optional_messages:
-        return
-
-    async with message.channel.typing():
-        bot_reply_message = await get_reply_message(message, optional_messages)
-
-    await send_messages(message.channel, bot_reply_message)
-
-
-async def send_messages(channel, message):
-    """Discordの制限にあわせて2000文字ごとに分割して送信"""
-    num_limit = 2000
-    short_messages = []
-    while len(message) > num_limit:
-        short_messages.append(message[:num_limit])
-        message = message[num_limit:]
-    short_messages.append(message)
-
-    for short_message in short_messages:
-        await channel.send(short_message)
+    if bot_reply_message:
+        await send_messages(message.channel, bot_reply_message)
 
 
 def set_text_model(model: str) -> None:
@@ -336,6 +103,7 @@ def set_text_model(model: str) -> None:
     text_model = validate_model(model)
 
 def run():
+    """ボットの起動"""
     global config
     global ai_client
     config = load_config()

--- a/discord_client.py
+++ b/discord_client.py
@@ -181,7 +181,7 @@ async def get_reply_message(message, optional_messages=[]):
     try:
         # --- Gemini 側でチャット生成 ---
         response = ai_client.chat.completions.create(
-            model=text_model,
+            model=ai_client.anthropic_models[0],
             messages=messages,
         )
         bot_reply_message = response.choices[0].message.content

--- a/discord_client.py
+++ b/discord_client.py
@@ -55,7 +55,7 @@ def ignore_message(message: discord.Message) -> bool:
 
 def check_if_channel_is_target(message: discord.Message) -> bool:
     """対象チャンネルかどうかを確認"""
-    return message.channel.id in config.target_channnel_ids
+    return message.channel.id in config.target_channel_ids
 
 @client.event
 async def on_ready():

--- a/discord_client.py
+++ b/discord_client.py
@@ -1,26 +1,12 @@
-import dataclasses
 import logging
 import os
-import re
 
 import discord
-import openai
-import requests
-from duckduckgo_search import DDGS
 
-import functions
-import summarizer
 from ai_client import load_ai_client
 from config import load_config
-
-intents = discord.Intents.default()
-intents.message_content = True
-client = discord.Client(intents=intents)
-
-config = None
-ai_client = None
-
-logger = logging.getLogger(__name__)
+from message_handler import process_message, send_messages
+from message_history import History
 
 # 利用可能なモデルのリスト
 AVAILABLE_MODELS = [
@@ -29,18 +15,10 @@ AVAILABLE_MODELS = [
     "claude-3-sonnet-20240229"  # Anthropic
 ]
 
+logger = logging.getLogger(__name__)
+
 def validate_model(model: str) -> str:
-    """モデル名を検証し、有効なモデル名を返す
-    
-    Args:
-        model: 検証するモデル名
-        
-    Returns:
-        検証済みのモデル名
-        
-    Raises:
-        ValueError: モデル名が無効な場合
-    """
+    """モデル名を検証し、有効なモデル名を返す"""
     if model not in AVAILABLE_MODELS:
         raise ValueError(
             f"Invalid model: {model}. "
@@ -48,206 +26,45 @@ def validate_model(model: str) -> str:
         )
     return model
 
+def set_text_model(model: str) -> None:
+    """テキストモデルを設定する"""
+    global text_model
+    text_model = validate_model(model)
+
 # デフォルトのテキストモデル（初期化時に検証）
 text_model = validate_model("gemini-2.0-flash")
 
-@dataclasses.dataclass
-class GPTMessage:
-    role: str
-    content: str
+# Discord設定
+intents = discord.Intents.default()
+intents.message_content = True
+client = discord.Client(intents=intents)
 
-
-class History:
-    def __init__(self, num_output=10):
-        self.messages = []
-        self.num_output = num_output
-
-    def add(self, message: GPTMessage):
-        self.messages.append(message)
-
-    def get_messages(self):
-        return [
-            dataclasses.asdict(message) for message in self.messages[-self.num_output:]
-        ]
-
-
+# グローバル変数
+config = None
+ai_client = None
 history = History()
 
+def ignore_message(message: discord.Message) -> bool:
+    """ボットのメッセージを無視"""
+    return message.author == client.user or message.author.bot
 
-def search_and_summarize(user_question: str) -> str:
-    """
-    DuckDuckGo API を使って検索し、出てきた情報をまとめて Gemini で要約する。
-    """
-
-    # 検索queryを作成
-    messages = [
-        {"role": "user", "content": user_question},
-        {
-            "role": "system",
-            "content": (
-                f"上記のユーザの質問「{user_question}」に対して、"
-                "検索するべき単語を抽出してください。回答は単語のみで構いません。"
-            ),
-        },
-    ]
-    try:
-        response = ai_client.chat.completions.create(
-            model=text_model,
-            messages=messages,
-        )
-        query = response.choices[0].message.content
-    except Exception as e:
-        logger.exception(e)
-        query = user_question
-
-    logger.info(f"Searching for: {query}")
-    # DuckDuckGo で検索
-    with DDGS() as ddgs:
-        results = list(ddgs.text(
-            keywords=query,
-            region='jp-jp',
-            max_results=10
-        ))
-
-    if not results:
-        return "検索結果が見つかりませんでした。"
-    
-    # 検索結果をまとめる
-    combined_text = f"{results}"
-
-    # モデルに送りすぎるとエラーになりやすいので適当にカット
-    combined_text = combined_text[:4096]
-
-    logger.info(f"Search snippets (trimmed): {combined_text[:100]}...")
-
-    if not combined_text.strip():
-        return "検索結果から有用な情報を取得できませんでした。"
-
-    # Gemini で要約
-    messages = [
-        {"role": "user", "content": combined_text},
-        {
-            "role": "system",
-            "content": (
-                f"上記の検索結果に基づいて、ユーザの質問「{query}」に答えるための"
-                "簡潔な日本語要約を作成してください。"
-            ),
-        },
-    ]
-    try:
-        response = ai_client.chat.completions.create(
-            model=text_model,
-            messages=messages,
-        )
-        summary = response.choices[0].message.content
-    except Exception as e:
-        logger.exception(e)
-        summary = "検索の要約時にエラーが発生しました。"
-    return summary
-
-
-def is_search_needed(user_message: str) -> bool:
-    """Determine if a search is needed based on the user's message."""
-    # Define keywords or patterns that indicate a search is needed
-    search_keywords = ["教えて", "とは", "何", "どうやって", "方法"]
-    if any(keyword in user_message for keyword in search_keywords):
-        return True
-
-    messages = [
-        {"role": "user", "content": user_message},
-        {
-            "role": "system",
-            "content": (
-                '上記のユーザーの発言に適切に答えるためにインターネット検索が必要であれば True、不要であれば False を返してください。必ず "True" または "False" のいずれかのみを返してください。'
-            ),
-        },
-    ]
-
-    try:
-        response = ai_client.chat.completions.create(
-            model=text_model,
-            messages=messages,
-        )
-        if "False" not in response.choices[0].message.content:
-            return True
-    except Exception as e:
-        logger.exception(e)
-    return False
-
-
-async def get_reply_message(message, optional_messages=[]):
-    """ユーザーのメッセージに対して、Gemini (via openai ライブラリ) による返信を取得する。
-    画像認識はできないので、画像要約だけ別途 openai_client を使う。
-    """
-    user_message = message.content
-    user_name = message.author.name
-
-    messages = history.get_messages()
-
-    # ロールプロンプトを system として追加
-    messages.append({"role": "system", "content": config.role_prompt})
-    # ユーザーからのメッセージ
-    messages.append({"role": "user", "content": user_name + ":\n" + user_message})
-    # LLMの知識不足を判定
-    if ai_client.is_knowledge_insufficient(text_model, messages):
-        logger.info("LLMの知識が不足しています。外部情報を検索します。")
-        summary = search_and_summarize(user_message)
-        optional_messages.append(
-            {
-                "role": "system",
-                "content": f"「{user_message}」の検索結果要約:\n{summary}"
-            }
-        )
-
-    # optional_messages があれば追記
-    if optional_messages:
-        messages.extend(optional_messages)
-    # アシスタント応答
-    messages.append({"role": "assistant", "content": config.role_name + ":\n"})
-
-    try:
-        # --- Gemini 側でチャット生成 ---
-        response = ai_client.chat.completions.create(
-            model=text_model,
-            messages=messages,
-        )
-        bot_reply_message = response.choices[0].message.content
-        bot_reply_message = bot_reply_message.replace(config.role_name + ":", "").strip()
-    except Exception as err:
-        logger.exception(err)
-        bot_reply_message = "Error: Gemini API failed"
-
-    # 履歴に追加
-    history.add(GPTMessage("user", user_name + ":\n" + user_message))
-    for optional_message in optional_messages:
-        history.add(GPTMessage(optional_message["role"], optional_message["content"]))
-    history.add(GPTMessage("assistant", config.role_name + ":\n" + bot_reply_message))
-
-    return bot_reply_message
-
+def check_if_channel_is_target(message: discord.Message) -> bool:
+    """対象チャンネルかどうかを確認"""
+    return message.channel.id in config.target_channnel_ids
 
 @client.event
 async def on_ready():
+    """ボット起動時の処理"""
     logger.info("We have logged in as {0.user}".format(client))
 
-
-def ignore_message(message):
-    return message.author == client.user or message.author.bot
-
-
-def check_if_channel_is_target(message):
-    return message.channel.id in config.target_channnel_ids
-
-
 @client.event
-async def on_message(message):
+async def on_message(message: discord.Message):
+    """メッセージ受信時の処理"""
     if ignore_message(message):
-        # ボット自身の発言は無視
         logger.info("ignore message")
         return
 
     if not check_if_channel_is_target(message):
-        # 対象チャンネル以外は無視
         logger.info("not target channel")
         return
 
@@ -255,93 +72,25 @@ async def on_message(message):
     logger.info(f"name:{message.author.name}")
     logger.info(f"message:{message.content[:50]}")
 
-    optional_messages = []
-
-    for attachment in message.attachments:
-        if not functions.is_image_attachment(attachment):
-            # 画像以外は無視
-            continue
-        try:
-            summarized_text = summarizer.summarize_image(attachment.url, ai_client)
-            logger.info(summarized_text[:50])
-            optional_messages.append(
-                {
-                    "role": "system",
-                    "content": "画像の要約:\n" + attachment.filename + "\n" + summarized_text
-                }
-            )
-        except RuntimeError:
-            pass
-
-    if functions.contains_url(message.content):
-        urls = functions.extract_urls(message.content)
-        try:
-            url = urls[0]
-            summarized_text = summarizer.summarize_webpage(url, ai_client)
-            logger.info(summarized_text[:50])
-            optional_messages.append(
-                {
-                    "role": "system",
-                    "content": "ページの要約:\n" + url + "\n" + summarized_text,
-                }
-            )
-        except RuntimeError:
-            pass
-
-    # --- ここから「～を教えて」を検出して検索する処理 ---
-    if is_search_needed(message.content):
-        # 検索して要約
-        summary = search_and_summarize(message.content)
-        # optional_messages に検索結果の要約を追加
-        optional_messages.append(
-            {
-                "role": "system",
-                "content": f"「{message.content}」の検索結果要約:\n{summary}"
-            }
+    async with message.channel.typing():
+        bot_reply_message = await process_message(
+            message,
+            history,
+            ai_client,
+            text_model,
+            config
         )
 
-    # 本文も添付もなく、かつ検索にもヒットしないなら返事しない
-    if not message.content and not optional_messages:
-        return
-
-    async with message.channel.typing():
-        bot_reply_message = await get_reply_message(message, optional_messages)
-
-    await send_messages(message.channel, bot_reply_message)
-
-
-async def send_messages(channel, message):
-    """Discordの制限にあわせて2000文字ごとに分割して送信"""
-    num_limit = 2000
-    short_messages = []
-    while len(message) > num_limit:
-        short_messages.append(message[:num_limit])
-        message = message[num_limit:]
-    short_messages.append(message)
-
-    for short_message in short_messages:
-        await channel.send(short_message)
-
-
-def set_text_model(model: str) -> None:
-    """テキストモデルを設定する
-    
-    Args:
-        model: 設定するモデル名
-        
-    Raises:
-        ValueError: モデル名が無効な場合
-    """
-    global text_model
-    text_model = validate_model(model)
+    if bot_reply_message:
+        await send_messages(message.channel, bot_reply_message)
 
 def run():
+    """ボットの起動"""
     global config
     global ai_client
     config = load_config()
     ai_client = load_ai_client()
     
-    # 環境変数でモデルを上書き可能に
     if "TEXT_MODEL" in os.environ:
         try:
             set_text_model(os.environ["TEXT_MODEL"])

--- a/discord_client.py
+++ b/discord_client.py
@@ -181,7 +181,7 @@ async def get_reply_message(message, optional_messages=[]):
     try:
         # --- Gemini 側でチャット生成 ---
         response = ai_client.chat.completions.create(
-            model=ai_client.anthropic_models[0],
+            model=text_model,
             messages=messages,
         )
         bot_reply_message = response.choices[0].message.content

--- a/message_handler.py
+++ b/message_handler.py
@@ -30,7 +30,7 @@ async def get_reply_message(
     # ユーザーからのメッセージ
     messages.append({"role": "user", "content": user_name + ":\n" + user_message})
     # LLMの知識不足を判定
-    if ai_client.is_knowledge_insufficient(text_model, messages):
+    if ai_client.is_knowledge_insufficient(text_model, messages) and not optional_messages:
         logger.info("LLMの知識が不足しています。外部情報を検索します。")
         summary = search_and_summarize(user_message, ai_client, text_model)
         optional_messages.append(

--- a/message_handler.py
+++ b/message_handler.py
@@ -1,0 +1,145 @@
+import logging
+from typing import List, Dict, Any
+
+import discord
+
+import functions
+import summarizer
+from message_history import GPTMessage, History
+from search_handler import search_and_summarize, is_search_needed
+
+logger = logging.getLogger(__name__)
+
+
+async def get_reply_message(
+    message: discord.Message,
+    history: History,
+    ai_client: Any,
+    text_model: str,
+    config: Any,
+    optional_messages: List[Dict[str, str]] = []
+) -> str:
+    """ユーザーのメッセージに対して、LLMによる返信を取得する"""
+    user_message = message.content
+    user_name = message.author.name
+
+    messages = history.get_messages()
+
+    # ロールプロンプトを system として追加
+    messages.append({"role": "system", "content": config.role_prompt})
+    # ユーザーからのメッセージ
+    messages.append({"role": "user", "content": user_name + ":\n" + user_message})
+    # LLMの知識不足を判定
+    if ai_client.is_knowledge_insufficient(text_model, messages):
+        logger.info("LLMの知識が不足しています。外部情報を検索します。")
+        summary = search_and_summarize(user_message, ai_client, text_model)
+        optional_messages.append(
+            {
+                "role": "system",
+                "content": f"「{user_message}」の検索結果要約:\n{summary}"
+            }
+        )
+
+    # optional_messages があれば追記
+    if optional_messages:
+        messages.extend(optional_messages)
+    # アシスタント応答
+    messages.append({"role": "assistant", "content": config.role_name + ":\n"})
+
+    try:
+        response = ai_client.chat.completions.create(
+            model=text_model,
+            messages=messages,
+        )
+        bot_reply_message = response.choices[0].message.content
+        bot_reply_message = bot_reply_message.replace(config.role_name + ":", "").strip()
+    except Exception as err:
+        logger.exception(err)
+        bot_reply_message = "Error: LLM API failed"
+
+    # 履歴に追加
+    history.add(GPTMessage("user", user_name + ":\n" + user_message))
+    for optional_message in optional_messages:
+        history.add(GPTMessage(optional_message["role"], optional_message["content"]))
+    history.add(GPTMessage("assistant", config.role_name + ":\n" + bot_reply_message))
+
+    return bot_reply_message
+
+
+async def process_message(
+    message: discord.Message,
+    history: History,
+    ai_client: Any,
+    text_model: str,
+    config: Any
+) -> str:
+    """メッセージを処理し、必要な情報を収集して返信を生成する"""
+    optional_messages = []
+
+    # 画像の処理
+    for attachment in message.attachments:
+        if not functions.is_image_attachment(attachment):
+            continue
+        try:
+            summarized_text = summarizer.summarize_image(attachment.url, ai_client)
+            logger.info(summarized_text[:50])
+            optional_messages.append(
+                {
+                    "role": "system",
+                    "content": "画像の要約:\n" + attachment.filename + "\n" + summarized_text
+                }
+            )
+        except RuntimeError:
+            pass
+
+    # URLの処理
+    if functions.contains_url(message.content):
+        urls = functions.extract_urls(message.content)
+        try:
+            url = urls[0]
+            summarized_text = summarizer.summarize_webpage(url, ai_client)
+            logger.info(summarized_text[:50])
+            optional_messages.append(
+                {
+                    "role": "system",
+                    "content": "ページの要約:\n" + url + "\n" + summarized_text,
+                }
+            )
+        except RuntimeError:
+            pass
+
+    # 検索が必要な場合の処理
+    if is_search_needed(message.content, ai_client, text_model):
+        summary = search_and_summarize(message.content, ai_client, text_model)
+        optional_messages.append(
+            {
+                "role": "system",
+                "content": f"「{message.content}」の検索結果要約:\n{summary}"
+            }
+        )
+
+    # 本文も添付もなく、かつ検索にもヒットしないなら返信なし
+    if not message.content and not optional_messages:
+        return ""
+
+    return await get_reply_message(
+        message,
+        history,
+        ai_client,
+        text_model,
+        config,
+        optional_messages
+    )
+
+
+async def send_messages(channel: discord.TextChannel, message: str) -> None:
+    """Discordの制限にあわせて2000文字ごとに分割して送信"""
+    num_limit = 2000
+    short_messages = []
+    while len(message) > num_limit:
+        short_messages.append(message[:num_limit])
+        message = message[num_limit:]
+    short_messages.append(message)
+
+    for short_message in short_messages:
+        await channel.send(short_message)

--- a/message_history.py
+++ b/message_history.py
@@ -1,0 +1,23 @@
+import dataclasses
+from typing import List, Dict
+
+
+@dataclasses.dataclass
+class GPTMessage:
+    role: str
+    content: str
+
+
+class History:
+    def __init__(self, num_output=10):
+        self.messages = []
+        self.num_output = num_output
+
+    def add(self, message: GPTMessage):
+        self.messages.append(message)
+
+    def get_messages(self) -> List[Dict[str, str]]:
+        """Get the last N messages in OpenAI format"""
+        return [
+            dataclasses.asdict(message) for message in self.messages[-self.num_output:]
+        ]

--- a/search_handler.py
+++ b/search_handler.py
@@ -1,0 +1,104 @@
+import logging
+from typing import List, Dict, Any
+
+from duckduckgo_search import DDGS
+
+logger = logging.getLogger(__name__)
+
+
+def search_and_summarize(user_question: str, ai_client: Any, text_model: str) -> str:
+    """DuckDuckGo APIを使って検索し、出てきた情報をまとめてLLMで要約する"""
+    # 検索queryを作成
+    messages = [
+        {"role": "user", "content": user_question},
+        {
+            "role": "system",
+            "content": (
+                f"上記のユーザの質問「{user_question}」に対して、"
+                "検索するべき単語を抽出してください。回答は単語のみで構いません。"
+            ),
+        },
+    ]
+    try:
+        response = ai_client.chat.completions.create(
+            model=text_model,
+            messages=messages,
+        )
+        query = response.choices[0].message.content
+    except Exception as e:
+        logger.exception(e)
+        query = user_question
+
+    logger.info(f"Searching for: {query}")
+    # DuckDuckGo で検索
+    with DDGS() as ddgs:
+        results = list(ddgs.text(
+            keywords=query,
+            region='jp-jp',
+            max_results=10
+        ))
+
+    if not results:
+        return "検索結果が見つかりませんでした。"
+    
+    # 検索結果をまとめる
+    combined_text = f"{results}"
+
+    # モデルに送りすぎるとエラーになりやすいので適当にカット
+    combined_text = combined_text[:4096]
+
+    logger.info(f"Search snippets (trimmed): {combined_text[:100]}...")
+
+    if not combined_text.strip():
+        return "検索結果から有用な情報を取得できませんでした。"
+
+    # LLMで要約
+    messages = [
+        {"role": "user", "content": combined_text},
+        {
+            "role": "system",
+            "content": (
+                f"上記の検索結果に基づいて、ユーザの質問「{query}」に答えるための"
+                "簡潔な日本語要約を作成してください。"
+            ),
+        },
+    ]
+    try:
+        response = ai_client.chat.completions.create(
+            model=text_model,
+            messages=messages,
+        )
+        summary = response.choices[0].message.content
+    except Exception as e:
+        logger.exception(e)
+        summary = "検索の要約時にエラーが発生しました。"
+    return summary
+
+
+def is_search_needed(user_message: str, ai_client: Any, text_model: str) -> bool:
+    """Determine if a search is needed based on the user's message."""
+    # Define keywords or patterns that indicate a search is needed
+    search_keywords = ["教えて", "とは", "何", "どうやって", "方法"]
+    if any(keyword in user_message for keyword in search_keywords):
+        return True
+
+    messages = [
+        {"role": "user", "content": user_message},
+        {
+            "role": "system",
+            "content": (
+                '上記のユーザーの発言に適切に答えるためにインターネット検索が必要であれば True、不要であれば False を返してください。必ず "True" または "False" のいずれかのみを返してください。'
+            ),
+        },
+    ]
+
+    try:
+        response = ai_client.chat.completions.create(
+            model=text_model,
+            messages=messages,
+        )
+        if "False" not in response.choices[0].message.content:
+            return True
+    except Exception as e:
+        logger.exception(e)
+    return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ def mock_env_vars(monkeypatch):
     monkeypatch.setenv("DISCORD_API_KEY", "test_discord_key")
     monkeypatch.setenv("OPENAI_API_KEY", "test_openai_key")
     monkeypatch.setenv("GEMINI_API_KEY", "test_gemini_key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test_anthropic_key")
     monkeypatch.setenv("CHANNEL_IDS", "123456789")
     monkeypatch.setenv("ROLE_PROMPT", "Test Role Prompt")
     monkeypatch.setenv("ROLE_NAME", "Test Role Name")

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -143,7 +143,8 @@ def test_hybrid_client_claude_model_not_configured(mock_openai_client, mock_gemi
 
 
 def test_message_format_conversion():
-    """メッセージフォーマット変換のテスト"""
+    """メッセージフォーマット変換のテスト
+    システムメッセージは別途処理されるため、変換結果には含まれない"""
     hybrid = HybridAIClient(
         openai_client=MagicMock(),
         gemini_client=MagicMock(),
@@ -158,10 +159,8 @@ def test_message_format_conversion():
 
     converted = hybrid._convert_messages_for_anthropic(messages)
 
-    assert len(converted) == 3
-    assert converted[0]["role"] == "system"
-    assert converted[0]["content"] == "System message"
-    assert converted[1]["role"] == "user"
-    assert converted[1]["content"] == "User message"
-    assert converted[2]["role"] == "assistant"
-    assert converted[2]["content"] == "Assistant message"
+    assert len(converted) == 2  # システムメッセージは除外される
+    assert converted[0]["role"] == "user"
+    assert converted[0]["content"] == "User message"
+    assert converted[1]["role"] == "assistant"
+    assert converted[1]["content"] == "Assistant message"

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -1,6 +1,7 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+from anthropic import Anthropic
 
 from ai_client import HybridAIClient
 
@@ -14,6 +15,16 @@ def mock_openai_client():
 @pytest.fixture
 def mock_gemini_client():
     client = MagicMock()
+    return client
+
+
+@pytest.fixture
+def mock_anthropic_client():
+    client = MagicMock()
+    # Mock the response format
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Hello from Claude")]
+    client.messages.create.return_value = mock_response
     return client
 
 
@@ -60,3 +71,97 @@ def test_hybrid_client_gemini_model_fallback_error(mock_openai_client, mock_gemi
     # モデルは "gpt-4o" にフォールバックされる
     called_args, called_kwargs = mock_openai_client.chat.completions.create.call_args
     assert called_kwargs["model"] == "gpt-4o"
+
+
+def test_hybrid_client_claude_model_success(mock_openai_client, mock_gemini_client, mock_anthropic_client):
+    """Claude-3-Sonnetモデルの正常系テスト"""
+    hybrid = HybridAIClient(
+        openai_client=mock_openai_client,
+        gemini_client=mock_gemini_client,
+        anthropic_client=mock_anthropic_client
+    )
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello from Claude."}
+    ]
+    response = hybrid.create("claude-3-sonnet-20240229", messages)
+
+    # Anthropicクライアントが正しく呼び出されること
+    mock_anthropic_client.messages.create.assert_called_once()
+    mock_gemini_client.chat.completions.create.assert_not_called()
+    mock_openai_client.chat.completions.create.assert_not_called()
+
+    # レスポンスが正しい形式に変換されていること
+    assert response.choices[0].message.content == "Hello from Claude"
+    assert response.choices[0].message.role == "assistant"
+
+    # システムメッセージとユーザーメッセージが正しく渡されていること
+    called_args = mock_anthropic_client.messages.create.call_args.kwargs
+    assert called_args["system"] == "You are a helpful assistant."
+    assert len(called_args["messages"]) == 1
+    assert called_args["messages"][0]["role"] == "user"
+    assert called_args["messages"][0]["content"] == "Hello from Claude."
+
+
+def test_hybrid_client_claude_model_fallback(mock_openai_client, mock_gemini_client, mock_anthropic_client):
+    """Claudeが失敗した場合のフォールバックテスト"""
+    mock_anthropic_client.messages.create.side_effect = Exception("Claude error")
+
+    hybrid = HybridAIClient(
+        openai_client=mock_openai_client,
+        gemini_client=mock_gemini_client,
+        anthropic_client=mock_anthropic_client
+    )
+
+    messages = [{"role": "user", "content": "Hello from Claude fallback."}]
+    hybrid.create("claude-3-sonnet-20240229", messages)
+
+    # Claudeが失敗してGPT-4にフォールバックすること
+    mock_anthropic_client.messages.create.assert_called_once()
+    mock_openai_client.chat.completions.create.assert_called_once()
+    called_args = mock_openai_client.chat.completions.create.call_args.kwargs
+    assert called_args["model"] == "gpt-4o"
+
+
+def test_hybrid_client_claude_model_not_configured(mock_openai_client, mock_gemini_client):
+    """Claudeクライアントが設定されていない場合のテスト"""
+    hybrid = HybridAIClient(
+        openai_client=mock_openai_client,
+        gemini_client=mock_gemini_client,
+        anthropic_client=None
+    )
+
+    messages = [{"role": "user", "content": "Hello without Claude."}]
+    hybrid.create("claude-3-sonnet-20240229", messages)
+
+    # Claudeクライアントがない場合はGeminiを試す
+    mock_gemini_client.chat.completions.create.assert_called_once_with(
+        model="claude-3-sonnet-20240229",
+        messages=messages,
+    )
+
+
+def test_message_format_conversion():
+    """メッセージフォーマット変換のテスト"""
+    hybrid = HybridAIClient(
+        openai_client=MagicMock(),
+        gemini_client=MagicMock(),
+        anthropic_client=MagicMock()
+    )
+
+    messages = [
+        {"role": "system", "content": "System message"},
+        {"role": "user", "content": "User message"},
+        {"role": "assistant", "content": "Assistant message"}
+    ]
+
+    converted = hybrid._convert_messages_for_anthropic(messages)
+
+    assert len(converted) == 3
+    assert converted[0]["role"] == "system"
+    assert converted[0]["content"] == "System message"
+    assert converted[1]["role"] == "user"
+    assert converted[1]["content"] == "User message"
+    assert converted[2]["role"] == "assistant"
+    assert converted[2]["content"] == "Assistant message"

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -75,7 +75,7 @@ def test_search_and_summarize_success(mock_ai_client, mock_ddgs):
         MagicMock(message=MagicMock(content="Dummy AI summary"))
     ]
 
-    result = search_and_summarize("Python の概要を教えて")
+    result = search_and_summarize("Python の概要を教えて", discord_client.ai_client, discord_client.text_model)
     assert "Dummy AI summary" in result  # 要約結果が返ってくる
 
     # DuckDuckGo の検索が呼ばれているかを確認
@@ -95,7 +95,7 @@ def test_search_and_summarize_no_results(mock_ai_client):
             MagicMock(message=MagicMock(content="No query found"))
         ]
 
-        result = search_and_summarize("何もヒットしないテスト")
+        result = search_and_summarize("何もヒットしないテスト", discord_client.ai_client, discord_client.text_model)
         assert "検索結果が見つかりませんでした" in result
 
 
@@ -130,7 +130,7 @@ async def test_get_reply_message_with_insufficient_knowledge(mock_ai_client, moc
         ]
 
         # Mock the search and summarize function
-        with patch("discord_client.search_and_summarize", return_value="検索結果の要約") as mock_search:
+        with patch("search_handler.search_and_summarize", return_value="検索結果の要約") as mock_search:
             result = await discord_client.process_message(mock_message, discord_client.history, discord_client.ai_client, discord_client.text_model, discord_client.config)
             assert "テスト応答" in result
             mock_search.assert_called_once_with("テストメッセージ", discord_client.ai_client, discord_client.text_model)

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch, AsyncMock
 import pytest
 
 import discord_client
-from discord_client import GPTMessage, History, search_and_summarize
+from message_history import GPTMessage, History
+from search_handler import search_and_summarize
 
 
 @pytest.fixture(autouse=True)
@@ -34,7 +35,7 @@ def mock_ai_client():
 @pytest.fixture
 def mock_ddgs():
     """DuckDuckGo の検索をモックする"""
-    with patch("discord_client.DDGS") as mock_ddgs_class:
+    with patch("search_handler.DDGS") as mock_ddgs_class:
         mock_ddgs_instance = MagicMock()
         mock_ddgs_instance.text.return_value = [
             "Result 1: This is the first snippet.",
@@ -85,7 +86,7 @@ def test_search_and_summarize_no_results(mock_ai_client):
     """
     DuckDuckGo で結果が一つも得られなかった場合にメッセージを返すか
     """
-    with patch("discord_client.DDGS") as mock_ddgs_class:
+    with patch("search_handler.DDGS") as mock_ddgs_class:
         mock_ddgs_instance = MagicMock()
         mock_ddgs_instance.text.return_value = []
         mock_ddgs_class.return_value.__enter__.return_value = mock_ddgs_instance
@@ -110,7 +111,7 @@ async def test_get_reply_message():
             MagicMock(message=MagicMock(content="テスト応答"))
         ]
         
-        result = await discord_client.get_reply_message(mock_message)
+        result = await discord_client.process_message(mock_message, discord_client.history, discord_client.ai_client, discord_client.text_model, discord_client.config)
         assert "テスト応答" in result
 
 
@@ -130,9 +131,9 @@ async def test_get_reply_message_with_insufficient_knowledge(mock_ai_client, moc
 
         # Mock the search and summarize function
         with patch("discord_client.search_and_summarize", return_value="検索結果の要約") as mock_search:
-            result = await discord_client.get_reply_message(mock_message)
+            result = await discord_client.process_message(mock_message, discord_client.history, discord_client.ai_client, discord_client.text_model, discord_client.config)
             assert "テスト応答" in result
-            mock_search.assert_called_once_with("テストメッセージ")
+            mock_search.assert_called_once_with("テストメッセージ", discord_client.ai_client, discord_client.text_model)
 
 @pytest.mark.asyncio
 async def test_send_messages():
@@ -158,6 +159,6 @@ async def test_on_message_ignore_bot():
     mock_message = MagicMock()
     mock_message.author = discord_client.client.user
     
-    with patch("discord_client.get_reply_message") as mock_get_reply:
+    with patch("message_handler.process_message") as mock_process:
         await discord_client.on_message(mock_message)
-        mock_get_reply.assert_not_called()
+        mock_process.assert_not_called()

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -123,14 +123,14 @@ async def test_get_reply_message_with_insufficient_knowledge(mock_ai_client, moc
     mock_message.author.name = "テストユーザー"
 
     # Mock the knowledge insufficiency check to return True
-    with patch("search_handler.is_search_needed", return_value=True):
+    with patch("discord_client.ai_client.is_knowledge_insufficient", return_value=True):
         # Mock the AI client response
         mock_ai_client.return_value.choices = [
             MagicMock(message=MagicMock(content="テスト応答"))
         ]
 
         # Mock the search and summarize function
-        with patch("search_handler.search_and_summarize", return_value="検索結果の要約") as mock_search:
+        with patch("message_handler.search_and_summarize", return_value="検索結果の要約") as mock_search:
             result = await discord_client.process_message(mock_message, discord_client.history, discord_client.ai_client, discord_client.text_model, discord_client.config)
             assert "テスト応答" in result
             mock_search.assert_called_once_with("テストメッセージ", discord_client.ai_client, discord_client.text_model)

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -123,7 +123,7 @@ async def test_get_reply_message_with_insufficient_knowledge(mock_ai_client, moc
     mock_message.author.name = "テストユーザー"
 
     # Mock the knowledge insufficiency check to return True
-    with patch("discord_client.ai_client.is_knowledge_insufficient", return_value=True):
+    with patch("search_handler.is_search_needed", return_value=True):
         # Mock the AI client response
         mock_ai_client.return_value.choices = [
             MagicMock(message=MagicMock(content="テスト応答"))


### PR DESCRIPTION
This PR integrates Claude-3-Sonnet into the existing HybridAIClient.

Changes:
- Add Anthropic API key configuration
- Add Claude-3-Sonnet model support to HybridAIClient
- Add message format conversion between OpenAI and Anthropic
- Add fallback to GPT-4 when Claude is not available

To use Claude-3-Sonnet:
1. Set ANTHROPIC_API_KEY environment variable
2. Use model="claude-3-sonnet-20240229" when calling create()